### PR TITLE
chore: add implementation of Staff API

### DIFF
--- a/src/Services/EGISZ/Frmo/Frmo.API/Frmo.API.http
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Frmo.API.http
@@ -227,4 +227,11 @@ Content-Type: application/json
 DELETE {{url}}/api/v1/org/depart?oid=1.2.643.5.1.13.13.12.2.77.7799&entityId=1.2.643.5.1.13.13.12.2.77.7799
 Content-Type: application/json
 
-###
+### Get Staff
+
+GET {{url}}/api/v1/org/staff?oid=1.2.643.5.1.13.13.12.2.77.7799
+Content-Type: application/json
+
+### Get Staff by entity
+GET {{url}}/api/v1/org/staff?oid=1.2.643.5.1.13.13.12.2.77.7799&entity=e50da88c-f7f0-4a8a-bde6-f491c2268abf
+Content-Type: application/json

--- a/src/Services/EGISZ/Frmo/Frmo.API/Models/Post.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Models/Post.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public record Post : BaseCodeNameItem
+{
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Models/PostFedCode.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Models/PostFedCode.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public record PostFedCode : BaseCodeNameItem
+{
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Models/Staff.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Models/Staff.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public record Staff
+{
+    [XmlElement("staffId")]
+    [JsonPropertyName("staffId")]
+    public string? StaffId { get; init; }
+
+    [XmlElement("staffNum")]
+    [JsonPropertyName("staffNum")]
+    public string StaffNum { get; init; } = default!;
+
+    [XmlElement("staffCreateDate")]
+    [JsonPropertyName("staffCreateDate")]
+    public DateTime StaffCreateDate { get; init; }
+
+    [XmlElement("beginDate")]
+    [JsonPropertyName("beginDate")]
+    public DateTime BeginDate { get; init; }
+
+    [XmlElement("endDate")]
+    [JsonPropertyName("endDate")]
+    public DateTime EndDate { get; init; }
+
+    [XmlArray("staffDetails")]
+    [XmlArrayItem("staffDetailsItem")]
+    [JsonPropertyName("staffDetails")]
+    public StaffDetail[]? StaffDetails { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Models/StaffDetail.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Models/StaffDetail.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public record StaffDetail
+{
+    [XmlElement("nrPmuDepartId")]
+    [JsonPropertyName("nrPmuDepartId")]
+    public string NrPmuDepartId { get; init; } = default!;
+
+    [XmlElement("departName")]
+    [JsonPropertyName("departName")]
+    public string? DepartName { get; init; }
+
+    [XmlElement("nrPmuDepartHospitalSubdivisionId")]
+    [JsonPropertyName("nrPmuDepartHospitalSubdivisionId")]
+    public string? NrPmuDepartHospitalSubdivisionId { get; init; }
+
+    [XmlElement("hospitalName")]
+    [JsonPropertyName("hospitalName")]
+    public string? HospitalName { get; init; }
+
+    [XmlElement("postFedCode")]
+    [JsonPropertyName("postFedCode")]
+    public PostFedCode PostFedCode { get; init; } = default!;
+
+    [XmlElement("post")]
+    [JsonPropertyName("post")]
+    public Post Post { get; init; } = default!;
+
+    [XmlElement("flCount")]
+    [JsonPropertyName("flCount")]
+    public int? FlCount { get; init; }
+
+    [XmlElement("averageAge")]
+    [JsonPropertyName("averageAge")]
+    public double? AverageAge { get; init; }
+
+    [XmlElement("rate")]
+    [JsonPropertyName("rate")]
+    public double Rate { get; init; }
+
+    [XmlElement("busyRate")]
+    [JsonPropertyName("busyRate")]
+    public double? BusyRate { get; init; }
+
+    [XmlElement("busyRateMain")]
+    [JsonPropertyName("busyRateMain")]
+    public double? BusyRateMain { get; init; }
+
+    [XmlElement("externalRate")]
+    [JsonPropertyName("externalRate")]
+    public double? ExternalRate { get; init; }
+
+    [XmlElement("vacancy")]
+    [JsonPropertyName("vacancy")]
+    public double? Vacancy { get; init; }
+
+    [XmlElement("staffNote")]
+    [JsonPropertyName("staffNote")]
+    public string? StaffNote { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Program.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddDataAccess(builder.Configuration);
 builder.Services.AddIpsIdentityProvider();
 builder.Services.AddOrganization();
 builder.Services.AddDepartment();
+builder.Services.AddStaff();
 
 builder.Services.AddDaprClient();
 builder.Services.AddDaprEventBus();
@@ -33,9 +34,11 @@ app.MapHealthChecks("/liveness", new HealthCheckOptions { Predicate = r => r.Nam
 // REST API endpoints
 app.MapOrganizations();
 app.MapDepartments();
+app.MapStaffs();
 
 // Dapr pub/sub endpoints
 app.MapPubSubOrganizations();
 app.MapPubSubDepartments();
+app.MapPubSubStaffs();
 
 app.Run();

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/CreateStaffRequest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/CreateStaffRequest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("createStaffRequest")]
+public record CreateStaffRequest
+{
+    [XmlElement("parameters")]
+    public required CreateStaffParameters Parameters { get; init; }
+
+    [XmlElement("content")]
+    public required CreateStaffContent Content { get; init; }
+}
+
+public record CreateStaffParameters
+{
+    [XmlElement("oid")]
+    public required string Oid { get; init; }
+}
+
+public record CreateStaffContent
+{
+    [XmlElement("staff")]
+    public required Staff Staff { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/CreateStaffResponse.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/CreateStaffResponse.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("createStaffResponse")]
+public record CreateStaffResponse : BaseResponse
+{
+    [XmlElement("content")]
+    [JsonPropertyName("content")]
+    public Entity? Content { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/DeleteStaffRequest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/DeleteStaffRequest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("deleteStaffRequest")]
+public record DeleteStaffRequest
+{
+    [XmlElement("parameters")]
+    public required DeleteStaffParameters Parameters { get; init; }
+}
+
+public record DeleteStaffParameters
+{
+    [XmlElement("oid")]
+    public required string Oid { get; init; }
+
+    [XmlElement("entityId")]
+    public required string EntityId { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/DeleteStaffResponse.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/DeleteStaffResponse.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("deleteStaffResponse")]
+public record DeleteStaffResponse : BaseResponse
+{
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/PubSubStaffEndpoint.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/PubSubStaffEndpoint.cs
@@ -11,31 +11,31 @@ internal static class PubSubStaffEndpoint
 
         var group = endpoints.MapGroup("api/v1/pubsub/org/staff");
 
-        group.MapPost("/get-all", [Topic(daprPubSubName, "GetStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetStaffIntegrationEventHandler handler) =>
+        group.MapPost("/", [Topic(daprPubSubName, "FrmoGetStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetStaffIntegrationEventHandler handler) =>
         {
             await handler.HandleAsync(@event);
             return Results.Ok();
         });
 
-        group.MapPost("/get", [Topic(daprPubSubName, "GetStaffByOidAndEntityIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetByEntityStaffIntegrationEventHandler handler) =>
+        group.MapPost("/get", [Topic(daprPubSubName, "FrmoGetStaffByEntityIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetByEntityStaffIntegrationEventHandler handler) =>
         {
             await handler.HandleAsync(@event);
             return Results.Ok();
         });
 
-        group.MapPost("/create", [Topic(daprPubSubName, "CreateStafffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] CreateStaffIntegrationEventHandler handler) =>
+        group.MapPost("/create", [Topic(daprPubSubName, "FrmoCreateStafffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] CreateStaffIntegrationEventHandler handler) =>
         {
             await handler.HandleAsync(@event);
             return Results.Ok();
         });
 
-        group.MapPost("/update", [Topic(daprPubSubName, "UpdateStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] UpdateDepartmentIntegrationEventHandler handler) =>
+        group.MapPost("/update", [Topic(daprPubSubName, "FrmoUpdateStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] UpdateDepartmentIntegrationEventHandler handler) =>
         {
             await handler.HandleAsync(@event);
             return Results.Ok();
         });
 
-        group.MapPost("/delete", [Topic(daprPubSubName, "DeleteStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] DeleteDepartmentIntegrationEventHandler handler) =>
+        group.MapPost("/delete", [Topic(daprPubSubName, "FrmoDeleteStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] DeleteDepartmentIntegrationEventHandler handler) =>
         {
             await handler.HandleAsync(@event);
             return Results.Ok();

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/PubSubStaffEndpoint.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/PubSubStaffEndpoint.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+internal static class PubSubStaffEndpoint
+{
+    public static RouteGroupBuilder MapPubSubStaffs(this IEndpointRouteBuilder endpoints)
+    {
+        const string daprPubSubName = "pubsub";
+
+        var group = endpoints.MapGroup("api/v1/pubsub/org/staff");
+
+        group.MapPost("/get-all", [Topic(daprPubSubName, "GetStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetStaffIntegrationEventHandler handler) =>
+        {
+            await handler.HandleAsync(@event);
+            return Results.Ok();
+        });
+
+        group.MapPost("/get", [Topic(daprPubSubName, "GetStaffByOidAndEntityIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] GetByEntityStaffIntegrationEventHandler handler) =>
+        {
+            await handler.HandleAsync(@event);
+            return Results.Ok();
+        });
+
+        group.MapPost("/create", [Topic(daprPubSubName, "CreateStafffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] CreateStaffIntegrationEventHandler handler) =>
+        {
+            await handler.HandleAsync(@event);
+            return Results.Ok();
+        });
+
+        group.MapPost("/update", [Topic(daprPubSubName, "UpdateStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] UpdateDepartmentIntegrationEventHandler handler) =>
+        {
+            await handler.HandleAsync(@event);
+            return Results.Ok();
+        });
+
+        group.MapPost("/delete", [Topic(daprPubSubName, "DeleteStaffIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] DeleteDepartmentIntegrationEventHandler handler) =>
+        {
+            await handler.HandleAsync(@event);
+            return Results.Ok();
+        });
+
+        return group;
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/StaffEndpoint.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Endpoints/StaffEndpoint.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+internal static class StaffEndpoint
+{
+    public static RouteGroupBuilder MapStaffs(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup("api/v1/org/staff");
+
+        group.MapGet("/", async (IStaffService staffService, string oid, string? entity) =>
+        {
+            if (entity is null)
+            {
+                var staffs = await staffService.GetAsync(oid);
+                return Results.Ok(staffs);
+            }
+            
+            var staff = await staffService.GetByEntityAsync(oid, entity);
+            return Results.Ok(staff);
+        });
+
+        group.MapPost("/", async (IStaffService staffService, string oid, Staff staff) =>
+        {
+            var response = await staffService.CreateAsync(oid, staff);
+
+            return Results.Ok(response);
+        });
+
+        group.MapPut("/", async (IStaffService staffService, string oid, string entityId, Staff staff) =>
+        {
+            var response = await staffService.UpdateAsync(oid, entityId, staff);
+
+            return Results.Ok(response);
+        });
+
+        group.MapDelete("/", async (IStaffService staffService, string oid, string entityId) =>
+        {
+            var response = await staffService.DeleteAsync(oid, entityId);
+
+            return Results.Ok(response);
+        });
+
+        return group;
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/CreateStaffIntegrationEventHandler.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/CreateStaffIntegrationEventHandler.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+
+namespace ParusRx.Frmo.API;
+
+public class CreateStaffIntegrationEventHandler(IParusRxStore store, IStaffService service, ILogger<CreateStaffIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - ({IntegrationEvent})", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            byte[] data = await store.ReadDataRequestAsync(id);
+
+            var request = XmlSerializerUtility.Deserialize<CreateStaffRequest>(data)
+                ?? throw new InvalidOperationException($"Cannot deserialize request data for integration event: {@event.Id}");
+
+            var response = await service.CreateAsync(request.Parameters.Oid, request.Content.Staff, cancellationToken);
+
+            var responseBytes = XmlSerializerUtility.Serialize(response)
+                ?? throw new InvalidOperationException($"Cannot serialize response data for integration event: {@event.Id}");
+
+            await store.SaveDataResponseAsync(id, responseBytes);
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/DeleteStaffIntegrationEventHandler.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/DeleteStaffIntegrationEventHandler.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public class DeleteStaffIntegrationEventHandler(IParusRxStore store, IStaffService service, ILogger<DeleteStaffIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - ({IntegrationEvent})", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            byte[] data = await store.ReadDataRequestAsync(id);
+
+            var request = XmlSerializerUtility.Deserialize<DeleteStaffRequest>(data)
+                ?? throw new InvalidOperationException($"Cannot deserialize request data for integration event: {@event.Id}");
+
+            var response = await service.DeleteAsync(request.Parameters.Oid, request.Parameters.EntityId, cancellationToken);
+
+            var responseBytes = XmlSerializerUtility.Serialize(response)
+                ?? throw new InvalidOperationException($"Cannot serialize response data for integration event: {@event.Id}");
+
+            await store.SaveDataResponseAsync(id, responseBytes);
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/GetByEntityStaffIntegrationEventHandler.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/GetByEntityStaffIntegrationEventHandler.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public class GetByEntityStaffIntegrationEventHandler(IParusRxStore store, IStaffService service, ILogger<GetByEntityStaffIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - ({IntegrationEvent})", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            byte[] data = await store.ReadDataRequestAsync(id);
+
+            var request = XmlSerializerUtility.Deserialize<StaffByEntityRequest>(data)
+                ?? throw new InvalidOperationException($"Cannot deserialize request data for integration event: {@event.Id}");
+
+            var response = await service.GetByEntityAsync(request.Parameters.Oid, request.Parameters.Entity, cancellationToken);
+
+            var responseBytes = XmlSerializerUtility.Serialize(response)
+                ?? throw new InvalidOperationException($"Cannot serialize response data for integration event: {@event.Id}");
+
+            await store.SaveDataResponseAsync(id, responseBytes);
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/GetStaffIntegrationEventHandler.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/GetStaffIntegrationEventHandler.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public class GetStaffIntegrationEventHandler(IParusRxStore store, IStaffService service, ILogger<GetStaffIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - ({IntegrationEvent})", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            byte[] data = await store.ReadDataRequestAsync(id);
+
+            var request = XmlSerializerUtility.Deserialize<StaffRequest>(data)
+                ?? throw new InvalidOperationException($"Cannot deserialize request data for integration event: {@event.Id}");
+
+            var response = await service.GetAsync(request.Parameters.Oid, cancellationToken);
+
+            var responseBytes = XmlSerializerUtility.Serialize(response)
+                ?? throw new InvalidOperationException($"Cannot serialize response data for integration event: {@event.Id}");
+
+            await store.SaveDataResponseAsync(id, responseBytes);
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/UpdateStaffIntegrationEventHandler.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Handlers/UpdateStaffIntegrationEventHandler.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+
+namespace ParusRx.Frmo.API;
+
+public class UpdateStaffIntegrationEventHandler(IParusRxStore store, IStaffService service, ILogger<UpdateStaffIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - ({IntegrationEvent})", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            byte[] data = await store.ReadDataRequestAsync(id);
+
+            var request = XmlSerializerUtility.Deserialize<UpdateStaffRequest>(data)
+                ?? throw new InvalidOperationException($"Cannot deserialize request data for integration event: {@event.Id}");
+
+            var response = await service.UpdateAsync(request.Parameters.Oid, request.Parameters.EntityId, request.Content.Staff, cancellationToken);
+
+            var responseBytes = XmlSerializerUtility.Serialize(response)
+                ?? throw new InvalidOperationException($"Cannot serialize response data for integration event: {@event.Id}");
+
+            await store.SaveDataResponseAsync(id, responseBytes);
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Services/IStaffService.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Services/IStaffService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public interface IStaffService
+{
+    ValueTask<StaffResponse> GetAsync(string oid, CancellationToken cancellationToken = default);
+    ValueTask<StaffByEntityResponse> GetByEntityAsync(string oid, string entity, CancellationToken cancellationToken = default);
+    ValueTask<CreateStaffResponse> CreateAsync(string oid, Staff staff, CancellationToken cancellationToken = default);
+    ValueTask<UpdateStaffResponse> UpdateAsync(string oid, string entityId, Staff staff, CancellationToken cancellationToken = default);
+    ValueTask<DeleteStaffResponse> DeleteAsync(string oid, string entityId, CancellationToken cancellationToken = default);
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Services/StaffService.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/Services/StaffService.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+public class StaffService(HttpClient httpClient, IOptionsSnapshot<FrmoSettings> settings) : IStaffService
+{
+    public async ValueTask<StaffResponse> GetAsync(string oid, CancellationToken cancellationToken = default)
+    {
+        string url = $"{settings.Value.Url}/org/staff?oid={oid}";
+
+        var response = await httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<StaffResponse>(cancellationToken) ?? new();
+    }
+
+    public async ValueTask<StaffByEntityResponse> GetByEntityAsync(string oid, string entity, CancellationToken cancellationToken = default)
+    {
+        string url = $"{settings.Value.Url}/org/staff/get?oid={oid}&entity={entity}";
+
+        var response = await httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<StaffByEntityResponse>(cancellationToken) ?? new();
+    }
+
+    public async ValueTask<CreateStaffResponse> CreateAsync(string oid, Staff staff, CancellationToken cancellationToken = default)
+    {
+        string url = $"{settings.Value.Url}/org/staff?oid={oid}";
+
+        var response = await httpClient.PostAsJsonAsync(url, staff, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<CreateStaffResponse>(cancellationToken) ?? new();
+    }
+
+    public async ValueTask<UpdateStaffResponse> UpdateAsync(string oid, string entityId, Staff staff, CancellationToken cancellationToken = default)
+    {
+        string url = $"{settings.Value.Url}/org/staff?oid={oid}&entityId={entityId}";
+
+        var response = await httpClient.PutAsJsonAsync(url, staff, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<UpdateStaffResponse>(cancellationToken) ?? new();
+    }
+
+    public async ValueTask<DeleteStaffResponse> DeleteAsync(string oid, string entityId, CancellationToken cancellationToken = default)
+    {
+        string url = $"{settings.Value.Url}/org/staff?oid={oid}&entityId={entityId}";
+
+        var response = await httpClient.DeleteAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadFromJsonAsync<DeleteStaffResponse>(cancellationToken) ?? new();
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffByEntityRequest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffByEntityRequest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("staffByEntityRequest")]
+public record StaffByEntityRequest
+{
+    [XmlElement("parameters")]
+    public required StaffByEntityParameters Parameters { get; init; }
+}
+
+public record StaffByEntityParameters
+{
+    [XmlElement("oid")]
+    public required string Oid { get; init; }
+
+    [XmlElement("entity")]
+    public required string Entity { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffByEntityResponse.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffByEntityResponse.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("staffByEntityResponse")]
+public record StaffByEntityResponse : BaseResponse
+{
+    [XmlElement("content")]
+    [JsonPropertyName("content")]
+    public Staff? Content { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffRequest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffRequest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("staffRequest")]
+public record StaffRequest
+{
+    [XmlElement("parameters")]
+    public required StaffParameters Parameters { get; init; }
+}
+
+public record StaffParameters
+{
+    [XmlElement("oid")]
+    public required string Oid { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffResponse.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffResponse.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("staffResponse")]
+public record StaffResponse : BaseResponse
+{
+    [XmlArray("content")]
+    [XmlArrayItem("staff")]
+    [JsonPropertyName("content")]
+    public Staff[]? Content { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffServiceCollectionExtensions.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/StaffServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class StaffServiceCollectionExtensions
+{
+    public static IServiceCollection AddStaff(this IServiceCollection services) 
+    {
+        services.AddHttpClient<IStaffService, StaffService>()
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler 
+            { 
+                ClientCertificateOptions = ClientCertificateOption.Manual,
+                ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true
+            })
+            .AddHttpMessageHandler<HttpClientAuthorizationDelegatingHandler>();
+
+        services.AddTransient<GetStaffIntegrationEventHandler>();
+        services.AddTransient<GetByEntityStaffIntegrationEventHandler>();
+        services.AddTransient<CreateStaffIntegrationEventHandler>();
+        services.AddTransient<UpdateStaffIntegrationEventHandler>();
+        services.AddTransient<DeleteStaffIntegrationEventHandler>();
+
+        return services;
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/UpdateStaffRequest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/UpdateStaffRequest.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("updateStaffRequest")]
+public record UpdateStaffRequest
+{
+    [XmlElement("parameters")]
+    public required UpdateStaffParameters Parameters { get; init; }
+
+    [XmlElement("content")]
+    public required UpdateStaffContent Content { get; init; }
+}
+
+public record UpdateStaffParameters
+{
+    [XmlElement("oid")]
+    public required string Oid { get; init; }
+
+    [XmlElement("entityId")]
+    public required string EntityId { get; init; }
+}
+
+public record UpdateStaffContent
+{
+    [XmlElement("staff")]
+    public required Staff Staff { get; init; }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.API/Staffs/UpdateStaffResponse.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.API/Staffs/UpdateStaffResponse.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.API;
+
+[XmlRoot("updateStaffResponse")]
+public record UpdateStaffResponse : BaseResponse
+{
+}

--- a/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/CreateStaffIntegrationEventHandlerTest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/CreateStaffIntegrationEventHandlerTest.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.Tests;
+
+public class CreateStaffIntegrationEventHandlerTest
+{
+    private readonly Mock<IParusRxStore> _storeMock;
+    private readonly Mock<IStaffService> _serviceMock;
+    private readonly Mock<ILogger<CreateStaffIntegrationEventHandler>> _loggerMock;
+
+    public CreateStaffIntegrationEventHandlerTest()
+    {
+        _storeMock = new Mock<IParusRxStore>();
+        _serviceMock = new Mock<IStaffService>();
+        _loggerMock = new Mock<ILogger<CreateStaffIntegrationEventHandler>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_SaveDataResponse()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        CreateStaffRequest request = new()
+        {
+            Parameters = new() { Oid = "1.2.643.5.1.13.13.12.2.77.7799" },
+            Content = new()
+            {
+                Staff = new()
+                {
+                    StaffId = "e50da88c-f7f0-4a8a-bde6-f491c2268abf"
+                }
+            }
+        };
+
+        CreateStaffResponse response = new()
+        {
+            RequestId = Guid.NewGuid().ToString(),
+            Message = null,
+            Content = new() { EntityId = "9acd20fe-ac30-45bc-a254-d60aa9b0be4e" }
+        };
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ReturnsAsync(XmlSerializerUtility.Serialize(request)!);
+        _storeMock.Setup(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.CreateAsync(request.Parameters.Oid, request.Content.Staff, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var handler = new CreateStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once());
+        _serviceMock.Verify(s => s.CreateAsync(request.Parameters.Oid, request.Content.Staff, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithException_SaveErrorAndLogError()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ThrowsAsync(new InvalidOperationException());
+
+        var handler = new CreateStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Never());
+        _serviceMock.Verify(s => s.CreateAsync(It.IsAny<string>(), It.IsAny<Staff>(), It.IsAny<CancellationToken>()), Times.Never());
+        
+        _storeMock.Verify(x => x.ErrorAsync(@event.Body, It.IsAny<string>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), 
+            Times.Once);
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/DeleteStaffIntgrationEventHandlerTest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/DeleteStaffIntgrationEventHandlerTest.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.Tests;
+
+public class DeleteStaffIntgrationEventHandlerTest
+{
+    private readonly Mock<IParusRxStore> _storeMock;
+    private readonly Mock<IStaffService> _serviceMock;
+    private readonly Mock<ILogger<DeleteStaffIntegrationEventHandler>> _loggerMock;
+
+    public DeleteStaffIntgrationEventHandlerTest()
+    {
+        _storeMock = new Mock<IParusRxStore>();
+        _serviceMock = new Mock<IStaffService>();
+        _loggerMock = new Mock<ILogger<DeleteStaffIntegrationEventHandler>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_SaveDataResponse()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        DeleteStaffRequest request = new()
+        {
+            Parameters = new()
+            {
+                Oid = "1.2.643.5.1.13.13.12.2.77.7799",
+                EntityId = "1.2.643.5.1.13.13.12.2.77.7799"
+            }
+        };
+
+        DeleteStaffResponse response = new()
+        {
+            RequestId = Guid.NewGuid().ToString(),
+            Message = null
+        };
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ReturnsAsync(XmlSerializerUtility.Serialize(request)!);
+        _storeMock.Setup(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.DeleteAsync(request.Parameters.Oid, request.Parameters.EntityId, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var handler = new DeleteStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+        
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once());
+        _serviceMock.Verify(s => s.DeleteAsync(request.Parameters.Oid, request.Parameters.EntityId, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithException_SaveErrorAndLogError()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ThrowsAsync(new InvalidOperationException());
+        
+        var handler = new DeleteStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Never());
+        _serviceMock.Verify(s => s.DeleteAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
+
+
+        _storeMock.Verify(s => s.ErrorAsync(@event.Body, It.IsAny<string>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), 
+            Times.Once);
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/GetByOidAndEntityStaffIntegrationEventHandlerTest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/GetByOidAndEntityStaffIntegrationEventHandlerTest.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.Tests;
+
+public class GetByOidAndEntityStaffIntegrationEventHandlerTest
+{
+    private readonly Mock<IParusRxStore> _storeMock;
+    private readonly Mock<IStaffService> _serviceMock;
+    private readonly Mock<ILogger<GetByEntityStaffIntegrationEventHandler>> _loggerMock;
+
+    public GetByOidAndEntityStaffIntegrationEventHandlerTest()
+    {
+        _storeMock = new Mock<IParusRxStore>();
+        _serviceMock = new Mock<IStaffService>();
+        _loggerMock = new Mock<ILogger<GetByEntityStaffIntegrationEventHandler>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_SaveDataResponse()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        StaffByEntityRequest request = new()
+        {
+            Parameters = new()
+            {
+                Oid = "1.2.643.5.1.13.13.12.2.77.7799",
+                Entity = "66f74ec3-9f2c-49b5-b641-0a7f7d31810b"
+            }
+        };
+
+        StaffByEntityResponse response = new()
+        {
+            RequestId = Guid.NewGuid().ToString(),
+            Message = null,
+            Content = new Staff
+            {
+                StaffId = "e50da88c-f7f0-4a8a-bde6-f491c2268abf"
+            }
+        };
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ReturnsAsync(XmlSerializerUtility.Serialize(request)!);
+        _storeMock.Setup(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.GetByEntityAsync(request.Parameters.Oid, request.Parameters.Entity, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var handler = new GetByEntityStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once());
+        _serviceMock.Verify(s => s.GetByEntityAsync(request.Parameters.Oid, request.Parameters.Entity, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithInvalidRequest_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ThrowsAsync(new InvalidOperationException());
+
+        var handler = new GetByEntityStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(x => x.ErrorAsync(@event.Body, It.IsAny<string>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), 
+            Times.Once);
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/GetByOidStaffIntegrationEventHandlerTest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/GetByOidStaffIntegrationEventHandlerTest.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.Tests;
+
+public class GetByOidStaffIntegrationEventHandlerTest
+{
+    private readonly Mock<IParusRxStore> _storeMock;
+    private readonly Mock<IStaffService> _serviceMock;
+    private readonly Mock<ILogger<GetStaffIntegrationEventHandler>> _loggerMock;
+
+    public GetByOidStaffIntegrationEventHandlerTest()
+    {
+        _storeMock = new Mock<IParusRxStore>();
+        _serviceMock = new Mock<IStaffService>();
+        _loggerMock = new Mock<ILogger<GetStaffIntegrationEventHandler>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_SaveDataResponse()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        StaffRequest request = new()
+        {
+            Parameters = new()
+            {
+                Oid = "1.2.643.5.1.13.13.12.2.77.7799"
+            }
+        };
+
+        StaffResponse response = new()
+        {
+            RequestId = Guid.NewGuid().ToString(),
+            Message = null,
+            Content =
+            [
+                new Staff
+                {
+                    StaffId = "e50da88c-f7f0-4a8a-bde6-f491c2268abf"
+                }
+            ]
+        };
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ReturnsAsync(XmlSerializerUtility.Serialize(request)!);
+        _storeMock.Setup(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.GetAsync(request.Parameters.Oid, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var handler = new GetStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once());
+        _serviceMock.Verify(s => s.GetAsync(request.Parameters.Oid, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithInvalidRequest_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ThrowsAsync(new InvalidOperationException());
+
+        var handler = new GetStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(x => x.ErrorAsync(@event.Body, It.IsAny<string>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), 
+            Times.Once);
+    }
+}

--- a/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/UpdateStaffIntegrationEventHandlerTest.cs
+++ b/src/Services/EGISZ/Frmo/Frmo.Tests/Staffs/UpdateStaffIntegrationEventHandlerTest.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) The Parus RX Authors. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ParusRx.Frmo.Tests;
+
+public class UpdateStaffIntegrationEventHandlerTest
+{
+    private readonly Mock<IParusRxStore> _storeMock;
+    private readonly Mock<IStaffService> _serviceMock;
+    private readonly Mock<ILogger<UpdateStaffIntegrationEventHandler>> _loggerMock;
+
+    public UpdateStaffIntegrationEventHandlerTest()
+    {
+        _storeMock = new Mock<IParusRxStore>();
+        _serviceMock = new Mock<IStaffService>();
+        _loggerMock = new Mock<ILogger<UpdateStaffIntegrationEventHandler>>();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_SaveDataResponse()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        UpdateStaffRequest request = new()
+        {
+            Parameters = new()
+            {
+                Oid = "1.2.643.5.1.13.13.12.2.77.7799",
+                EntityId = "1.2.643.5.1.13.13.12.2.77.7799"
+            },
+            Content = new()
+            {
+                Staff = new()
+                {
+                    StaffId = "e50da88c-f7f0-4a8a-bde6-f491c2268abf"
+                }
+            }
+        };
+
+        UpdateStaffResponse response = new()
+        {
+            RequestId = Guid.NewGuid().ToString(),
+            Message = null
+        };
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ReturnsAsync(XmlSerializerUtility.Serialize(request)!);
+        _storeMock.Setup(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+        _serviceMock.Setup(s => s.UpdateAsync(request.Parameters.Oid, request.Parameters.EntityId, request.Content.Staff, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var handler = new UpdateStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once());
+        _serviceMock.Verify(s => s.UpdateAsync(request.Parameters.Oid, request.Parameters.EntityId, request.Content.Staff, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithException_SaveErrorAndLogError()
+    {
+        // Arrange
+        MqIntegrationEvent @event = new(Guid.NewGuid().ToString());
+
+        _storeMock.Setup(s => s.ReadDataRequestAsync(@event.Body)).ThrowsAsync(new InvalidOperationException());
+        
+        var handler = new UpdateStaffIntegrationEventHandler(_storeMock.Object, _serviceMock.Object, _loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        _storeMock.Verify(s => s.ReadDataRequestAsync(@event.Body), Times.Once());
+        _storeMock.Verify(s => s.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Never());
+        _serviceMock.Verify(s => s.UpdateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Staff>(), It.IsAny<CancellationToken>()), Times.Never());
+
+
+        _storeMock.Verify(s => s.ErrorAsync(@event.Body, It.IsAny<string>()), Times.Once());
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()), 
+            Times.Once);
+    }
+}


### PR DESCRIPTION
**New API endpoints:**
- `GET: api/v1/org/staff?oid={oid}`
- `GET: api/v1/org/staff?oid={oid}&entity={entity}`
- `POST: api/v1/org/staff?oid={oid}`
- `PUT: api/v1/org/staff?oid={oid}&entity={entity}`
- `DELETE: api/v1/org/staff?oid={oid}&entity={entity}`

**New subscriptions:**
- `FrmoGetStaffIntegrationEvent (api/v1/pubsub/org/staff)`
- `FrmoGetStaffByEntityIntegrationEvent (api/v1/pubsub/org/staff/get)`
- `FrmoCreateStafffIntegrationEvent (api/v1/pubsub/org/staff/create)`
- `FrmoUpdateStaffIntegrationEvent (api/v1/pubsub/org/staff/update)`
- `FrmoDeleteStaffIntegrationEvent (api/v1/pubsub/org/staff/delete)`