### PR TITLE
Add POST Endpoint and Event Handler for Route Templates

### DIFF
--- a/src/Services/HRlink/HRlink.API/HRlink.API.http
+++ b/src/Services/HRlink/HRlink.API/HRlink.API.http
@@ -39,3 +39,13 @@ Content-Type: application/json
 }
 
 ###
+
+POST {{url}}/api/v1/pubsub/route-templates
+Accept: application/json
+Content-Type: application/json
+
+{
+    "body": "03693B95-D933-9B85-E063-910A14ACFEBF"
+}
+
+###

--- a/src/Services/HRlink/HRlink.API/Handlers/RouteTemplateRequestIntegrationEventHandler.cs
+++ b/src/Services/HRlink/HRlink.API/Handlers/RouteTemplateRequestIntegrationEventHandler.cs
@@ -21,17 +21,8 @@ public class RouteTemplateRequestIntegrationEventHandler(IParusRxStore store, IR
 
         try
         {
-            //byte[] data = await store.ReadDataRequestAsync(id);
-            //var request = XmlSerializerUtility.Deserialize<RouteTemplateRequest>(data);
-            var request = new RouteTemplateRequest
-            {
-                Authorization = new AuthorizationContext
-                { 
-                    ApiToken = "1d551d11-de1b-4c86-931a-11a8aaa5da0d",
-                    ClientId = "84af8abc-3720-4f7f-966a-05d2c6fcc8e2",
-                    Url = "https://testparusnik.hr-link.ru",
-                }
-            };
+            byte[] data = await store.ReadDataRequestAsync(id);
+            var request = XmlSerializerUtility.Deserialize<RouteTemplateRequest>(data);
 
             if (request is not null)
             {

--- a/src/Services/HRlink/HRlink.API/Handlers/RouteTemplateRequestIntegrationEventHandler.cs
+++ b/src/Services/HRlink/HRlink.API/Handlers/RouteTemplateRequestIntegrationEventHandler.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Handlers;
+
+/// <summary>
+/// The route template request integration event handler.
+/// </summary>
+/// <param name="store">The Parus RX store.</param>
+/// <param name="service">The route template service.</param>
+/// <param name="logger">The logger.</param>
+public class RouteTemplateRequestIntegrationEventHandler(IParusRxStore store, IRouteTemplateService service, ILogger<RouteTemplateRequestIntegrationEventHandler> logger)
+    : IIntegrationEventHandler<MqIntegrationEvent>
+{
+    /// </inheritdoc>
+    public async Task HandleAsync(MqIntegrationEvent @event, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+
+        string id = @event.Body;
+
+        try
+        {
+            //byte[] data = await store.ReadDataRequestAsync(id);
+            //var request = XmlSerializerUtility.Deserialize<RouteTemplateRequest>(data);
+            var request = new RouteTemplateRequest
+            {
+                Authorization = new AuthorizationContext
+                { 
+                    ApiToken = "1d551d11-de1b-4c86-931a-11a8aaa5da0d",
+                    ClientId = "84af8abc-3720-4f7f-966a-05d2c6fcc8e2",
+                    Url = "https://testparusnik.hr-link.ru",
+                }
+            };
+
+            if (request is not null)
+            {
+                var routeTemplateResponse = await service.GetRouteTemplatesAsync(request, cancellationToken);
+                if (routeTemplateResponse is not null)
+                {
+                    byte[]? response = XmlSerializerUtility.Serialize(routeTemplateResponse);
+                    if (response is not null)
+                    {
+                        await store.SaveDataResponseAsync(id, response);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            await store.ErrorAsync(id, ex.Message);
+            logger.LogError(ex, "Error handling integration event: {IntegrationEventId} - {IntegrationEvent}", @event.Id, @event);
+        }
+    }
+}

--- a/src/Services/HRlink/HRlink.API/Models/AutoSelectParticipantRuleType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/AutoSelectParticipantRuleType.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the type of the auto-select participant rule.
+/// </summary>
+public enum AutoSelectParticipantRuleType
+{
+    /// <summary>
+    /// Autocomplete department head manager.
+    /// </summary>
+    [XmlEnum("DEPARTMENT_HEAD_MANAGER")]
+    DEPARTMENT_HEAD_MANAGER,
+
+    /// <summary>
+    /// Autocomplete functional head manager.
+    /// </summary>
+    [XmlEnum("FUNCTIONAL_HEAD_MANAGER")]
+    FUNCTIONAL_HEAD_MANAGER
+}

--- a/src/Services/HRlink/HRlink.API/Models/RouteSigningType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/RouteSigningType.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the method of signing on a route.
+/// </summary>
+public enum RouteSigningType
+{
+    /// <summary>
+    /// The PEP.
+    /// </summary>
+    [XmlEnum("SES")]
+    SES,
+
+    /// <summary>
+    /// The cloud UNEP.
+    /// </summary>
+    [XmlEnum("CLOUD_NQES")]
+    CLOUD_NQES,
+
+    /// <summary>
+    /// The Qualified Electronic Signature.
+    /// </summary>
+    [XmlEnum("QES")]
+    QES,
+
+    /// <summary>
+    /// Through the portal "Work in Russia".
+    /// </summary>
+    [XmlEnum("PRR")]
+    PRR,
+
+    /// <summary>
+    /// The government key.
+    /// </summary>
+    [XmlEnum("GOV_KEY")]
+    GOV_KEY,
+
+    /// <summary>
+    /// Any suitable method.
+    /// </summary>
+    [XmlEnum("ANY_APPLICABLE")]
+    ANY_APPLICABLE
+}

--- a/src/Services/HRlink/HRlink.API/Models/RouteTemplateRequest.cs
+++ b/src/Services/HRlink/HRlink.API/Models/RouteTemplateRequest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the route template request.
+/// </summary>
+[XmlRoot("routeTemplateRequest")]
+public record RouteTemplateRequest
+{
+    /// <summary>
+    /// Gets or sets the authorization context.
+    /// </summary>
+    [XmlElement("authorization")]
+    public required AuthorizationContext Authorization { get; init; }
+
+    /// <summary>
+    /// Gets or sets the signing object type.
+    /// </summary>
+    [XmlElement("signingObjectType")]
+    public SigningObjectType? SigningObjectType { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/RouteTemplateResponse.cs
+++ b/src/Services/HRlink/HRlink.API/Models/RouteTemplateResponse.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a route template response.
+/// </summary>
+[XmlRoot("routeTemplateResponse")]
+public record RouteTemplateResponse
+{
+    /// <summary>
+    /// Gets or sets the result of the files upload.
+    /// </summary>
+    [XmlElement("result")]
+    [JsonPropertyName("result")]
+    public required bool Result { get; init; }
+
+    [XmlArray("signingRouteTemplates")]
+    [XmlArrayItem("signingRouteTemplate")]
+    [JsonPropertyName("signingRouteTemplates")]
+    public required SigningRouteTemplate[] SigningRouteTemplates { get; init; } = [];
+}

--- a/src/Services/HRlink/HRlink.API/Models/ShortLegalEntity.cs
+++ b/src/Services/HRlink/HRlink.API/Models/ShortLegalEntity.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a short legal entity.
+/// </summary>
+[XmlRoot("legalEntity")]
+public record ShortLegalEntity
+{
+    /// <summary>
+    /// Gets or sets the name of the legal entity.
+    /// </summary>
+    [XmlElement("name")]
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets or sets the short name of the legal entity.
+    /// </summary>
+    [XmlElement("shortName")]
+    [JsonPropertyName("shortName")]
+    public required string ShortName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the external identifier of the legal entity.
+    /// </summary>
+    [XmlElement("externalId")]
+    [JsonPropertyName("externalId")]
+    public string? ExternalId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the legal entity.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningObjectType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningObjectType.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a signing object type enumeration.
+/// </summary>
+public enum SigningObjectType
+{
+    /// <summary>
+    /// The document.
+    /// </summary>
+    [XmlEnum("DOCUMENT")]
+    DOCUMENT,
+
+    /// <summary>
+    /// The application.
+    /// </summary>
+    [XmlEnum("APPLICATION ")]
+    APPLICATION
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteParticipantActionType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteParticipantActionType.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the type of an action performed by a participant in a signing route.
+/// </summary>
+public enum SigningRouteParticipantActionType
+{
+    /// <summary>
+    /// The signing.
+    /// </summary>
+    [XmlEnum("SIGNING")]
+    SIGNING,
+
+    /// <summary>
+    /// The approving.
+    /// </summary>
+    [XmlEnum("APPROVING")]
+    APPROVING,
+
+    /// <summary>
+    /// The receiving.
+    /// </summary>
+    [XmlEnum("RECEIVING")]
+    RECEIVING,
+
+    /// <summary>
+    /// The processing.
+    /// </summary>
+    [XmlEnum("PROCESSING")]
+    PROCESSING
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteParticipantType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteParticipantType.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the type of a participant in a signing route.
+/// </summary>
+public enum SigningRouteParticipantType
+{
+    /// <summary>
+    /// The participant is an employee.
+    /// </summary>
+    [XmlEnum("EMPLOYEE")]
+    EMPLOYEE,
+
+    /// <summary>
+    /// The participant is an employer.
+    /// </summary>
+    [XmlEnum("EMPLOYER")]
+    EMPLOYER,
+
+    /// <summary>
+    /// The participant is a fixed employee.
+    /// </summary>
+    [XmlEnum("FIXED_EMPLOYEE")]
+    FIXED_EMPLOYEE,
+
+    /// <summary>
+    /// The participant is a selectable employee.
+    /// </summary>
+    [XmlEnum("SELECTABLE_EMPLOYEE")]
+    SELECTABLE_EMPLOYEE,
+
+    /// <summary>
+    /// The participant with a specific role.
+    /// </summary>
+    [XmlEnum("ROLE")]
+    ROLE,
+
+    /// <summary>
+    /// The participant is a responsible person.
+    /// </summary>
+    [XmlEnum("RESPONSIBLE")]
+    RESPONSIBLE
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteStageCompletenessCondition.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteStageCompletenessCondition.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a signing route stage completeness condition enumeration.
+/// </summary>
+public enum SigningRouteStageCompletenessCondition
+{
+    /// <summary>
+    /// The all.
+    /// </summary>
+    [XmlEnum("ALL")]
+    ALL,
+
+    /// <summary>
+    /// The any.
+    /// </summary>
+    [XmlEnum("ANY")]
+    ANY
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteStageType.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteStageType.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a signing route stage type enumeration.
+/// </summary>
+public enum SigningRouteStageType
+{
+    /// <summary>
+    /// The signing.
+    /// </summary>
+    [XmlEnum("SIGNING")]
+    SIGNING,
+
+    /// <summary>
+    /// The receiving.
+    /// </summary>
+    [XmlEnum("RECEIVING")]
+    RECEIVING
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplate.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplate.cs
@@ -50,8 +50,9 @@ public record SigningRouteTemplate
     /// </summary>
     [XmlElement("templateKey")]
     [JsonPropertyName("templateKey")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public TemplateKey? TemplateKey { get; init; }
+    //[JsonConverter(typeof(JsonStringEnumConverter))]
+    //public TemplateKey? TemplateKey { get; init; }
+    public string? TemplateKey { get; init; }
 
     /// <summary>
     /// Gets or sets the created date of the signing route template.

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplate.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplate.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a signing route template.
+/// </summary>
+[XmlRoot("signingRouteTemplate")]
+public record SigningRouteTemplate
+{
+    /// <summary>
+    /// Gets or sets the identifier of the signing route template.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the client.
+    /// </summary>
+    [XmlElement("clientId")]
+    [JsonPropertyName("clientId")]
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the signing route template.
+    /// </summary>
+    [XmlElement("name")]
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the signing object.
+    /// </summary>
+    [XmlElement("signingObjectType")]
+    [JsonPropertyName("signingObjectType")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SigningObjectType? SigningObjectType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the external identifier of the signing route template.
+    /// </summary>
+    [XmlElement("externalId")]
+    [JsonPropertyName("externalId")]
+    public string? ExternalId { get; init; }
+
+    /// <summary>
+    /// Gets or sets keys of system signing routes for application.
+    /// </summary>
+    [XmlElement("templateKey")]
+    [JsonPropertyName("templateKey")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public TemplateKey? TemplateKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the created date of the signing route template.
+    /// </summary>
+    [XmlElement("createdDate")]
+    [JsonPropertyName("createdDate")]
+    public DateTime? CreatedDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the deactivated date of the signing route template.
+    /// </summary>
+    [XmlElement("deactivatedDate")]
+    [JsonPropertyName("deactivatedDate")]
+    public DateTime? DeactivatedDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the stages of the signing route template.
+    /// </summary>
+    [XmlArray("stages")]
+    [XmlArrayItem("stage")]
+    [JsonPropertyName("stages")]
+    public SigningRouteTemplateStage[]? Stages { get; init; }
+
+    [XmlArray("legalEntities")]
+    [XmlArrayItem("legalEntity")]
+    [JsonPropertyName("legalEntities")]
+    public ShortLegalEntity[]? LegalEntities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the version of the signing route template.
+    /// </summary>
+    [XmlElement("version")]
+    [JsonPropertyName("version")]
+    public int? Version { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipant.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipant.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+[XmlRoot("signingRouteTemplateParticipant")]
+public record SigningRouteTemplateParticipant
+{
+    /// <summary>
+    /// Gets or sets the identifier of the participant.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ID of the signing route template stage to which the participant belongs.
+    /// </summary>
+    [XmlElement("templateStageId")]
+    [JsonPropertyName("templateStageId")]
+    public string? TemplateStageId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the participant.
+    /// </summary>
+    [XmlElement("type")]
+    [JsonPropertyName("type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SigningRouteParticipantType? Type { get; init; }
+
+    /// <summary>
+    /// Gets or sets the action type required from the participant in the signing route stage.
+    /// </summary>
+    [XmlElement("actionType")]
+    [JsonPropertyName("actionType")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SigningRouteParticipantActionType? ActionType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the signing type for the participant in the signing route.
+    /// </summary>
+    [XmlElement("signingType")]
+    [JsonPropertyName("signingType")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public RouteSigningType? SigningType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the participant.
+    /// </summary>
+    /// </summary>
+    [XmlElement("placeholder")]
+    [JsonPropertyName("placeholder")]
+    public string? Placeholder { get; init; }
+
+    /// <summary>
+    /// Gets or sets the employee of the participant.
+    /// </summary>
+    [XmlElement("employee")]
+    [JsonPropertyName("employee")]
+    public SigningRouteTemplateParticipantEmployee? Employee { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether a set of signers is created based on the participant.
+    /// </summary>
+    [XmlElement("isMultipleSigners")]
+    [JsonPropertyName("isMultipleSigners")]
+    public bool? IsMultipleSigners { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the rule for automatically selecting participants.
+    /// </summary>
+    [XmlElement("autoSelectRuleType")]
+    [JsonPropertyName("autoSelectRuleType")]
+    public AutoSelectParticipantRuleType? AutoSelectRuleType { get; init; }
+
+    /// <summary>
+    /// Get or sets the required participant.
+    /// </summary>
+    [XmlElement("required")]
+    [JsonPropertyName("required")]
+    public bool? Required { get; init; }
+
+    /// <summary>
+    /// Gets or sets the unchangeable participant.
+    /// </summary>
+    [XmlElement("unchangeable")]
+    [JsonPropertyName("unchangeable")]
+    public bool? Unchangeable { get; init; }
+
+    /// <summary>
+    /// Gets or sets the related participant identifier.
+    /// </summary>
+    [XmlElement("relatedParticipantId")]
+    [JsonPropertyName("relatedParticipantId")]
+    public string? RelatedParticipantId { get; init; }
+
+    [XmlElement("version")]
+    [JsonPropertyName("version")]
+    public long? Version { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipant.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipant.cs
@@ -71,6 +71,7 @@ public record SigningRouteTemplateParticipant
     /// </summary>
     [XmlElement("autoSelectRuleType")]
     [JsonPropertyName("autoSelectRuleType")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public AutoSelectParticipantRuleType? AutoSelectRuleType { get; init; }
 
     /// <summary>

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployee.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployee.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents an employee participant in a signing route template.
+/// </summary>
+[XmlRoot("signingRouteTemplateParticipantEmployee")]
+public record SigningRouteTemplateParticipantEmployee
+{
+    /// <summary>
+    /// Gets or sets the last name of the employee.
+    /// </summary>
+    [XmlElement("lastName")]
+    [JsonPropertyName("lastName")]
+    public string? LastName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the first name of the employee.
+    /// </summary>
+    [XmlElement("firstName")]
+    [JsonPropertyName("firstName")]
+    public string? FirstName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the patronymic of the employee.
+    /// </summary>
+    [XmlElement("patronymic")]
+    [JsonPropertyName("patronymic")]
+    public string? Patronymic { get; init; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the employee.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the department of the employee.
+    /// </summary>
+    [XmlElement("department")]
+    [JsonPropertyName("department")]
+    public SigningRouteTemplateParticipantEmployeeDepartment? Department { get; init; }
+
+    /// <summary>
+    /// Gets or sets the position of the employee.
+    /// </summary>
+    [XmlElement("position")]
+    [JsonPropertyName("position")]
+    public SigningRouteTemplateParticipantEmployeePosition? Position { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployeeDepartment.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployeeDepartment.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a department of an employee participant in a signing route template.
+/// </summary>
+[XmlRoot("department")]
+public record SigningRouteTemplateParticipantEmployeeDepartment
+{
+    /// <summary>
+    /// Gets or sets the identifier of the department.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the department.
+    /// </summary>
+    [XmlElement("name")]
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployeePosition.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateParticipantEmployeePosition.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents the position of an employee participant in a signing route template.
+/// </summary>
+[XmlRoot("position")]
+public record SigningRouteTemplateParticipantEmployeePosition
+{
+    /// <summary>
+    /// Gets or sets the identifier of the position.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the position.
+    /// </summary>
+    [XmlElement("name")]
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateStage.cs
+++ b/src/Services/HRlink/HRlink.API/Models/SigningRouteTemplateStage.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a signing route template stage.
+/// </summary>
+[XmlRoot("signingRouteTemplateStage")]
+public record SigningRouteTemplateStage
+{
+    /// <summary>
+    /// Gets or sets the identifier of the stage.
+    /// </summary>
+    [XmlElement("id")]
+    [JsonPropertyName("id")]
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the signing route template.
+    /// </summary>
+    [XmlElement("signingRouteTemplateId")]
+    [JsonPropertyName("signingRouteTemplateId")]
+    public string? SigningRouteTemplateId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of the stage.
+    /// </summary>
+    [XmlElement("indexNumber")]
+    [JsonPropertyName("indexNumber")]
+    public long? IndexNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of the stage.
+    /// </summary>
+    [XmlElement("type")]
+    [JsonPropertyName("type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SigningRouteStageType? Type { get; init; }
+
+    /// <summary>
+    /// Gets or sets the condition of completeness of the stage.
+    /// </summary>
+    [XmlElement("completenessCondition")]
+    [JsonPropertyName("completenessCondition")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SigningRouteStageCompletenessCondition? CompletenessCondition { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the responsible is enabled at this stage.
+    /// </summary>
+    [XmlElement("responsibleEnabled")]
+    [JsonPropertyName("responsibleEnabled")]
+    public bool? ResponsibleEnabled { get; init; }
+
+    /// <summary>
+    /// Gets or sets the identifier of the responsible.
+    /// </summary>
+    [XmlElement("canDeleteBeforeStageCompleted")]
+    [JsonPropertyName("canDeleteBeforeStageCompleted")]
+    public bool? CanDeleteBeforeStageCompleted { get; init; }
+
+    /// <summary>
+    /// Gets or sets participants of the stage.
+    /// </summary>
+    [XmlArray("participants")]
+    [XmlArrayItem("participant")]
+    [JsonPropertyName("participants")]
+    public SigningRouteTemplateParticipant[]? Participants { get; init; }
+
+    /// <summary>
+    /// Gets or sets the version of the stage.
+    /// </summary>
+    [XmlElement("version")]
+    [JsonPropertyName("version")]
+    public long? Version { get; init; }
+}

--- a/src/Services/HRlink/HRlink.API/Models/TemplateKey.cs
+++ b/src/Services/HRlink/HRlink.API/Models/TemplateKey.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Models;
+
+/// <summary>
+/// Represents a template key enumeration.
+/// </summary>
+public enum TemplateKey
+{
+    /// <summary>
+    /// The approver and HR.
+    /// </summary>
+    [XmlEnum("APPROVER_AND_HR")]
+    APPROVER_AND_HR,
+
+    /// <summary>
+    /// The only HR.
+    /// </summary>
+    [XmlEnum("ONLY_HR")]
+    ONLY_HR,
+
+    /// <summary>
+    /// The two HR and approver.
+    /// </summary>
+    [XmlEnum("TWO_HR_AND_APPROVER")]
+    TWO_HR_AND_APPROVER,
+
+    /// <summary>
+    /// The two approver and HR.
+    /// </summary>
+    [XmlEnum("TWO_APPROVER_AND_HR ")]
+    TWO_APPROVER_AND_HR
+}

--- a/src/Services/HRlink/HRlink.API/Program.cs
+++ b/src/Services/HRlink/HRlink.API/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddTransient<UserBulkDataSyncTaskRequestIntegrationEventHandler
 builder.Services.AddTransient<FilesUploadRequestIntegrationEventHandler>();
 builder.Services.AddTransient<CreateDocumentGroupIntegrationEventHandler>();
 builder.Services.AddTransient<SendToSigningIntegrationEventHandler>();
+builder.Services.AddTransient<RouteTemplateRequestIntegrationEventHandler>();
 
 // Data access
 string provider = builder.Configuration["Database:Provider"] ?? string.Empty;
@@ -117,6 +118,12 @@ pubsub.MapPost("/document-groups", [Topic(DaprPubSubName, "CreateDocumentGroupIn
 });
 
 pubsub.MapPost("/document-groups/send-to-signing", [Topic(DaprPubSubName, "SendToSigningIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] SendToSigningIntegrationEventHandler handler) =>
+{
+    await handler.HandleAsync(@event);
+    return Results.Created();
+});
+
+pubsub.MapPost("/route-templates", [Topic(DaprPubSubName, "RouteTemplateListIntegrationEvent")] async ([FromBody] MqIntegrationEvent @event, [FromServices] RouteTemplateRequestIntegrationEventHandler handler) =>
 {
     await handler.HandleAsync(@event);
     return Results.Created();

--- a/src/Services/HRlink/HRlink.API/Program.cs
+++ b/src/Services/HRlink/HRlink.API/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddHttpClient();
 
 builder.Services.AddHttpClient<IFileService, FileService>();
 builder.Services.AddHttpClient<IDocumentService, DocumentService>();
+builder.Services.AddHttpClient<IRouteTemplateService, RouteTemplateService>();
 
 builder.Services.AddTransient<IBulkDataSyncTaskClient, BulkDataSyncTaskClient>();
 builder.Services.AddTransient<DocumentTypeRequestIntegrationEventHandler>();

--- a/src/Services/HRlink/HRlink.API/Services/IRouteTemplateService.cs
+++ b/src/Services/HRlink/HRlink.API/Services/IRouteTemplateService.cs
@@ -14,5 +14,5 @@ public interface IRouteTemplateService
     /// <param name="request">The <see cref="RouteTemplateRequest"/>.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The <see cref="RouteTemplateResponse"/>.</returns>
-    ValueTask<RouteTemplateResponse> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default);
+    ValueTask<RouteTemplateResponse?> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Services/HRlink/HRlink.API/Services/IRouteTemplateService.cs
+++ b/src/Services/HRlink/HRlink.API/Services/IRouteTemplateService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace ParusRx.HRlink.API.Services;
+
+/// <summary>
+/// Provides methods allowing to work with route templates in HRlink.
+/// </summary>
+public interface IRouteTemplateService
+{
+    /// <summary>
+    /// Gets the route template.
+    /// </summary>
+    /// <param name="request">The <see cref="RouteTemplateRequest"/>.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The <see cref="RouteTemplateResponse"/>.</returns>
+    ValueTask<RouteTemplateResponse> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
+++ b/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace ParusRx.HRlink.API.Services;
+
+/// <summary>
+/// Provides methods allowing to work with route templates in HRlink.
+/// </summary>
+/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+public sealed class RouteTemplateService(HttpClient httpClient) : IRouteTemplateService
+{
+    /// <inheritdoc />
+    public async ValueTask<RouteTemplateResponse> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string uri = $"{request.Authorization.Url}/api/v1/clients/{request.Authorization.ClientId}/routeTemplates";
+        httpClient.DefaultRequestHeaders.Add("User-Api-Token", request.Authorization.ApiToken);
+
+        HttpResponseMessage response = await httpClient.GetAsync(uri, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorDetails = await response.Content.ReadFromJsonAsync<ErrorDetails>(cancellationToken);
+            StringBuilder sb = new();
+            sb.AppendLine(errorDetails?.ErrorMessage);
+            sb.AppendLine($"Error ID: {errorDetails?.ErrorId}");
+            sb.AppendLine($"Error Code: {errorDetails?.ErrorCode}");
+            sb.AppendLine($"Operation Code: {errorDetails?.OperationCode}");
+            if (errorDetails?.ErrorData is not null)
+            {
+                sb.AppendLine("Error Data:");
+                foreach (var (key, value) in errorDetails.ErrorData)
+                {
+                    sb.AppendLine($"{key}: {value?.ToString()}");
+                }
+            }
+            throw new HttpRequestException(
+                sb.ToString(),
+                null,
+                response.StatusCode);
+        }
+
+        var routeTemplateResponse = await response.Content.ReadFromJsonAsync<RouteTemplateResponse>(cancellationToken);
+        return routeTemplateResponse is null
+            ? throw new HttpRequestException("Failed to deserialize RouteTemplateResponse.", null, response.StatusCode)
+            : routeTemplateResponse;
+    }
+}

--- a/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
+++ b/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
@@ -12,7 +12,7 @@ namespace ParusRx.HRlink.API.Services;
 public sealed class RouteTemplateService(HttpClient httpClient) : IRouteTemplateService
 {
     /// <inheritdoc />
-    public async ValueTask<RouteTemplateResponse> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default)
+    public async ValueTask<RouteTemplateResponse?> GetRouteTemplatesAsync(RouteTemplateRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -43,8 +43,6 @@ public sealed class RouteTemplateService(HttpClient httpClient) : IRouteTemplate
         }
 
         var routeTemplateResponse = await response.Content.ReadFromJsonAsync<RouteTemplateResponse>(cancellationToken);
-        return routeTemplateResponse is null
-            ? throw new HttpRequestException("Failed to deserialize RouteTemplateResponse.", null, response.StatusCode)
-            : routeTemplateResponse;
+        return routeTemplateResponse;
     }
 }

--- a/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
+++ b/src/Services/HRlink/HRlink.API/Services/RouteTemplateService.cs
@@ -41,7 +41,7 @@ public sealed class RouteTemplateService(HttpClient httpClient) : IRouteTemplate
                 null,
                 response.StatusCode);
         }
-
+        var str = await response.Content.ReadAsStringAsync(cancellationToken);
         var routeTemplateResponse = await response.Content.ReadFromJsonAsync<RouteTemplateResponse>(cancellationToken);
         return routeTemplateResponse;
     }

--- a/src/Services/HRlink/HRlink.Tests/Handlers/RouteTemplateRequestIntegrationEventHandlerTests.cs
+++ b/src/Services/HRlink/HRlink.Tests/Handlers/RouteTemplateRequestIntegrationEventHandlerTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Moq;
+
+namespace ParusRx.HRlink.API.Tests.Handlers;
+
+public class RouteTemplateRequestIntegrationEventHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_WithValidRequest_CallsRouteTemplateServiceAndSavesResponse()
+    {
+        // Arrange
+        var @event = new MqIntegrationEvent(Guid.NewGuid().ToString());
+
+        var request = new RouteTemplateRequest
+        {
+            Authorization = new AuthorizationContext
+            {
+                Url = "https://demo.hr-link.ru",
+                ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
+                ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
+            }
+        };
+        var response = new RouteTemplateResponse
+        {
+            Result = true,
+            SigningRouteTemplates =
+            [
+                new SigningRouteTemplate
+                {
+                    Id = "1",
+                    Name = "Route 1"
+                }
+            ]
+        };
+
+        byte[]? data = XmlSerializerUtility.Serialize(request);
+        byte[]? responseData = XmlSerializerUtility.Serialize(response);
+
+        var storeMock = new Mock<IParusRxStore>();
+        storeMock.Setup(x => x.ReadDataRequestAsync(It.IsAny<string>())).ReturnsAsync(data!);
+        storeMock.Setup(x => x.SaveDataResponseAsync(It.IsAny<string>(), It.IsAny<byte[]>())).Returns(Task.CompletedTask);
+
+        var routeTemplateServiceMock = new Mock<IRouteTemplateService>();
+        routeTemplateServiceMock.Setup(x => x.GetRouteTemplatesAsync(It.IsAny<RouteTemplateRequest>(), It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+        var loggerMock = new Mock<ILogger<RouteTemplateRequestIntegrationEventHandler>>();
+
+        var handler = new RouteTemplateRequestIntegrationEventHandler(storeMock.Object, routeTemplateServiceMock.Object, loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        storeMock.Verify(x => x.SaveDataResponseAsync(@event.Body, It.IsAny<byte[]>()), Times.Once);
+        routeTemplateServiceMock.Verify(x => x.GetRouteTemplatesAsync(
+            It.Is<RouteTemplateRequest>(r => true),
+            It.Is<CancellationToken>(t => t.Equals(CancellationToken.None))), Times.Once);
+        storeMock.Verify(x => x.SaveDataResponseAsync(
+            It.Is<string>(id => id == @event.Body),
+            It.Is<byte[]>(data => data.SequenceEqual(responseData!))), Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithInvalidRequest_CallsErrorAsyncAndLogsError()
+    {
+        // Arrange
+        var @event = new MqIntegrationEvent(Guid.NewGuid().ToString());
+
+        var storeMock = new Mock<IParusRxStore>();
+        storeMock.Setup(x => x.ReadDataRequestAsync(It.IsAny<string>())).ThrowsAsync(new Exception("Test exception"));
+
+        var routeTemplateServiceMock = new Mock<IRouteTemplateService>();
+        var loggerMock = new Mock<ILogger<RouteTemplateRequestIntegrationEventHandler>>();
+
+        var handler = new RouteTemplateRequestIntegrationEventHandler(storeMock.Object, routeTemplateServiceMock.Object, loggerMock.Object);
+
+        // Act
+        await handler.HandleAsync(@event);
+
+        // Assert
+        storeMock.Verify(x => x.ErrorAsync(It.Is<string>(id => id == @event.Body), It.IsAny<string>()), Times.Once);
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains($"Error handling integration event: {@event.Id} - {@event}")),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            Times.Once);
+    }
+
+}

--- a/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
+++ b/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
@@ -1,113 +1,108 @@
 // Copyright (c) Alexander Bocharov.
 // Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
-using System;
+namespace ParusRx.HRlink.API.Tests.Services;
 
-using ParusRx.HRlink.API.Models;
-
-namespace ParusRx.HRlink.API.Tests.Services
+public class RouteTemplateServiceTests
 {
-    public class RouteTemplateServiceTests
+    [Fact]
+    public async Task GetRouteTemplatesAsync_WithNullRequest_ThrowsArgumentNullException()
     {
-        [Fact]
-        public async Task GetRouteTemplatesAsync_WithNullRequest_ThrowsArgumentNullException()
+        // Arrange
+        RouteTemplateRequest? request = null;
+        Mock<HttpClient> httpClient = new(MockBehavior.Loose);
+
+        RouteTemplateService service = new(httpClient.Object);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await service.GetRouteTemplatesAsync(request!));
+    }
+
+    [Fact]
+    public async Task GetRouteTemplatesAsync_WithValidRequest_ReturnsRouteTemplateResponse()
+    {
+        RouteTemplateRequest request = new RouteTemplateRequest
         {
-            // Arrange
-            RouteTemplateRequest? request = null;
-            Mock<HttpClient> httpClient = new(MockBehavior.Loose);
+            Authorization = new AuthorizationContext
+            {
+                Url = "https://demo.hr-link.ru",
+                ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
+                ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
+            }
+        };
 
-            RouteTemplateService service = new(httpClient.Object);
-
-            // Act & Assert
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await service.GetRouteTemplatesAsync(request!));
-        }
-
-        [Fact]
-        public async Task GetRouteTemplatesAsync_WithValidRequest_ReturnsRouteTemplateResponse()
+        HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
         {
-            RouteTemplateRequest request = new RouteTemplateRequest
-            {
-                Authorization = new AuthorizationContext
-                {
-                    Url = "https://demo.hr-link.ru",
-                    ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
-                    ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
-                }
-            };
+            Assert.Equal("https://demo.hr-link.ru/api/v1/clients/78DB35C3-64E4-4D06-B34D-793070E970C6/routeTemplates", request.RequestUri?.ToString());
 
-            HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
+            HttpResponseMessage response = new(HttpStatusCode.OK)
             {
-                Assert.Equal("https://demo.hr-link.ru/api/v1/clients/78DB35C3-64E4-4D06-B34D-793070E970C6/routeTemplates", request.RequestUri?.ToString());
-
-                HttpResponseMessage response = new(HttpStatusCode.OK)
+                Content = JsonContent.Create(new RouteTemplateResponse
                 {
-                    Content = JsonContent.Create(new RouteTemplateResponse
-                    {
-                        Result = true,
-                        SigningRouteTemplates = new SigningRouteTemplate[]
+                    Result = true,
+                    SigningRouteTemplates =
+                    [
+                        new SigningRouteTemplate
                         {
-                            new SigningRouteTemplate
-                            {
-                                Id = "1",
-                                Name = "Route 1"
-                            }
+                            Id = "1",
+                            Name = "Route 1"
                         }
-                    })
-                };
-
-                return Task.FromResult(response);
-            });
-
-            RouteTemplateService service = new(httpClient);
-
-            // Act
-            RouteTemplateResponse? response = await service.GetRouteTemplatesAsync(request);
-
-            // Assert
-            Assert.IsType<RouteTemplateResponse>(response);
-            Assert.NotNull(response);
-        }
-
-        [Theory]
-        [InlineData(HttpStatusCode.Unauthorized, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified API token is invalid.", "ErrorCode": "11.006", "OperationCode": "11.100" }""")]
-        [InlineData(HttpStatusCode.BadRequest, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified JSON does not match the expected format.", "ErrorCode": "11.021", "OperationCode": "11.181", "ErrorData": { "path": "documents[0]" } }""")]
-        [InlineData(HttpStatusCode.Forbidden, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified client is not allowed to perform this operation.", "ErrorCode": "10.000", "OperationCode": "11.082", "ErrorData": { "permission": "ROUTE_TEMPLATES" } }""")]
-        [InlineData(HttpStatusCode.InternalServerError, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "An error occurred while processing the request.", "ErrorCode": "11.000", "OperationCode": "21.100" }""")]
-        public async Task GetRouteTemplatesAsync_WithErrorResponse_ThrowsHttpRequestException(HttpStatusCode statusCode, string content)
-        {
-            RouteTemplateRequest request = new RouteTemplateRequest
-            {
-                Authorization = new AuthorizationContext
-                {
-                    Url = "https://demo.hr-link.ru",
-                    ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
-                    ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
-                }
+                    ]
+                })
             };
-            HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
-            {
-                HttpResponseMessage response = new(statusCode)
-                {
-                    Content = new StringContent(content)
-                };
-                return Task.FromResult(response);
-            });
-            RouteTemplateService service = new(httpClient);
-            // Act & Assert
-            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request));
-        }
 
+            return Task.FromResult(response);
+        });
 
-        private static HttpClient CreateHttpClientWithMockHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> valueFunction)
+        RouteTemplateService service = new(httpClient);
+
+        // Act
+        RouteTemplateResponse? response = await service.GetRouteTemplatesAsync(request);
+
+        // Assert
+        Assert.IsType<RouteTemplateResponse>(response);
+        Assert.NotNull(response);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified API token is invalid.", "ErrorCode": "11.006", "OperationCode": "11.100" }""")]
+    [InlineData(HttpStatusCode.BadRequest, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified JSON does not match the expected format.", "ErrorCode": "11.021", "OperationCode": "11.181", "ErrorData": { "path": "documents[0]" } }""")]
+    [InlineData(HttpStatusCode.Forbidden, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified client is not allowed to perform this operation.", "ErrorCode": "10.000", "OperationCode": "11.082", "ErrorData": { "permission": "ROUTE_TEMPLATES" } }""")]
+    [InlineData(HttpStatusCode.InternalServerError, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "An error occurred while processing the request.", "ErrorCode": "11.000", "OperationCode": "21.100" }""")]
+    public async Task GetRouteTemplatesAsync_WithErrorResponse_ThrowsHttpRequestException(HttpStatusCode statusCode, string content)
+    {
+        RouteTemplateRequest request = new RouteTemplateRequest
         {
-            Mock<HttpMessageHandler> mockHttpMessageHandler = new(MockBehavior.Strict);
-            mockHttpMessageHandler
-                .Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .Returns(valueFunction)
-                .Verifiable();
+            Authorization = new AuthorizationContext
+            {
+                Url = "https://demo.hr-link.ru",
+                ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
+                ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
+            }
+        };
+        HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
+        {
+            HttpResponseMessage response = new(statusCode)
+            {
+                Content = new StringContent(content)
+            };
+            return Task.FromResult(response);
+        });
+        RouteTemplateService service = new(httpClient);
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request));
+    }
 
-            return new HttpClient(mockHttpMessageHandler.Object);
-        }
+
+    private static HttpClient CreateHttpClientWithMockHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> valueFunction)
+    {
+        Mock<HttpMessageHandler> mockHttpMessageHandler = new(MockBehavior.Strict);
+        mockHttpMessageHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns(valueFunction)
+            .Verifiable();
+
+        return new HttpClient(mockHttpMessageHandler.Object);
     }
 }

--- a/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
+++ b/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
@@ -1,96 +1,113 @@
-//// Copyright (c) Alexander Bocharov.
-//// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+// Copyright (c) Alexander Bocharov.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
 
-//namespace ParusRx.HRlink.API.Tests.Services
-//{
-//    public class RouteTemplateServiceTests
-//    {
-//        [Fact]
-//        public async Task GetRouteTemplatesAsync_WithValidRequest_ReturnsRouteTemplateResponse()
-//        {
-//            // Arrange
-//            var httpClient = new HttpClient();
-//            var service = new RouteTemplateService(httpClient);
-//            var request = new RouteTemplateRequest
-//            {
-//                Authorization = new AuthorizationContext
-//                {
-//                    Url = "https://example.com",
-//                    ClientId = "123456",
-//                    ApiToken = "abc123"
-//                },
-//                SigningObjectType = SigningObjectType.DOCUMENT
-//            };
-//            var cancellationToken = CancellationToken.None;
+using System;
 
-//            // Act
-//            var response = await service.GetRouteTemplatesAsync(request, cancellationToken);
+using ParusRx.HRlink.API.Models;
 
-//            // Assert
-//            Assert.NotNull(response);
-//            Assert.True(response.Result);
-//            Assert.NotNull(response.SigningRouteTemplates);
-//        }
+namespace ParusRx.HRlink.API.Tests.Services
+{
+    public class RouteTemplateServiceTests
+    {
+        [Fact]
+        public async Task GetRouteTemplatesAsync_WithNullRequest_ThrowsArgumentNullException()
+        {
+            // Arrange
+            RouteTemplateRequest? request = null;
+            Mock<HttpClient> httpClient = new(MockBehavior.Loose);
 
-//        [Fact]
-//        public async Task GetRouteTemplatesAsync_WithInvalidRequest_ThrowsHttpRequestException()
-//        {
-//            // Arrange
-//            var httpClient = new HttpClient();
-//            var service = new RouteTemplateService(httpClient);
-//            var request = new RouteTemplateRequest
-//            {
-//                Authorization = new AuthorizationContext
-//                {
-//                    Url = "https://example.com",
-//                    ClientId = "123456",
-//                    ApiToken = "abc123"
-//                },
-//                SigningObjectType = null // Invalid request
-//            };
-//            var cancellationToken = CancellationToken.None;
+            RouteTemplateService service = new(httpClient.Object);
 
-//            // Act & Assert
-//            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request, cancellationToken));
-//        }
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await service.GetRouteTemplatesAsync(request!));
+        }
 
-//        [Fact]
-//        public async Task GetRouteTemplatesAsync_WithErrorResponse_ThrowsHttpRequestException()
-//        {
-//            // Arrange
-//            var httpClient = new HttpClient(new MockHttpMessageHandler(HttpStatusCode.BadRequest));
-//            var service = new RouteTemplateService(httpClient);
-//            var request = new RouteTemplateRequest
-//            {
-//                Authorization = new AuthorizationContext
-//                {
-//                    Url = "https://example.com",
-//                    ClientId = "123456",
-//                    ApiToken = "abc123"
-//                },
-//                SigningObjectType = SigningObjectType.DOCUMENT
-//            };
-//            var cancellationToken = CancellationToken.None;
+        [Fact]
+        public async Task GetRouteTemplatesAsync_WithValidRequest_ReturnsRouteTemplateResponse()
+        {
+            RouteTemplateRequest request = new RouteTemplateRequest
+            {
+                Authorization = new AuthorizationContext
+                {
+                    Url = "https://demo.hr-link.ru",
+                    ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
+                    ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
+                }
+            };
 
-//            // Act & Assert
-//            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request, cancellationToken));
-//        }
-//    }
+            HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
+            {
+                Assert.Equal("https://demo.hr-link.ru/api/v1/clients/78DB35C3-64E4-4D06-B34D-793070E970C6/routeTemplates", request.RequestUri?.ToString());
 
-//    // MockHttpMessageHandler to simulate HTTP response with a specific status code
-//    public class MockHttpMessageHandler : HttpMessageHandler
-//    {
-//        private readonly HttpStatusCode _statusCode;
+                HttpResponseMessage response = new(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new RouteTemplateResponse
+                    {
+                        Result = true,
+                        SigningRouteTemplates = new SigningRouteTemplate[]
+                        {
+                            new SigningRouteTemplate
+                            {
+                                Id = "1",
+                                Name = "Route 1"
+                            }
+                        }
+                    })
+                };
 
-//        public MockHttpMessageHandler(HttpStatusCode statusCode)
-//        {
-//            _statusCode = statusCode;
-//        }
+                return Task.FromResult(response);
+            });
 
-//        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-//        {
-//            var response = new HttpResponseMessage(_statusCode);
-//            return Task.FromResult(response);
-//        }
-//    }
-//}
+            RouteTemplateService service = new(httpClient);
+
+            // Act
+            RouteTemplateResponse? response = await service.GetRouteTemplatesAsync(request);
+
+            // Assert
+            Assert.IsType<RouteTemplateResponse>(response);
+            Assert.NotNull(response);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.Unauthorized, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified API token is invalid.", "ErrorCode": "11.006", "OperationCode": "11.100" }""")]
+        [InlineData(HttpStatusCode.BadRequest, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified JSON does not match the expected format.", "ErrorCode": "11.021", "OperationCode": "11.181", "ErrorData": { "path": "documents[0]" } }""")]
+        [InlineData(HttpStatusCode.Forbidden, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "The specified client is not allowed to perform this operation.", "ErrorCode": "10.000", "OperationCode": "11.082", "ErrorData": { "permission": "ROUTE_TEMPLATES" } }""")]
+        [InlineData(HttpStatusCode.InternalServerError, """{ "result": false, "ErrorId": "D7DFEB89-2883-4DFB-8D89-86B7CAFA3827", "ErrorMessage": "An error occurred while processing the request.", "ErrorCode": "11.000", "OperationCode": "21.100" }""")]
+        public async Task GetRouteTemplatesAsync_WithErrorResponse_ThrowsHttpRequestException(HttpStatusCode statusCode, string content)
+        {
+            RouteTemplateRequest request = new RouteTemplateRequest
+            {
+                Authorization = new AuthorizationContext
+                {
+                    Url = "https://demo.hr-link.ru",
+                    ClientId = "78DB35C3-64E4-4D06-B34D-793070E970C6",
+                    ApiToken = "81255B76-7F18-46E2-93C0-7ED60BE814F9"
+                }
+            };
+            HttpClient httpClient = CreateHttpClientWithMockHandler((request, cancellationToken) =>
+            {
+                HttpResponseMessage response = new(statusCode)
+                {
+                    Content = new StringContent(content)
+                };
+                return Task.FromResult(response);
+            });
+            RouteTemplateService service = new(httpClient);
+            // Act & Assert
+            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request));
+        }
+
+
+        private static HttpClient CreateHttpClientWithMockHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> valueFunction)
+        {
+            Mock<HttpMessageHandler> mockHttpMessageHandler = new(MockBehavior.Strict);
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .Returns(valueFunction)
+                .Verifiable();
+
+            return new HttpClient(mockHttpMessageHandler.Object);
+        }
+    }
+}

--- a/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
+++ b/src/Services/HRlink/HRlink.Tests/Services/RouteTemplateServiceTests.cs
@@ -1,0 +1,96 @@
+//// Copyright (c) Alexander Bocharov.
+//// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+//namespace ParusRx.HRlink.API.Tests.Services
+//{
+//    public class RouteTemplateServiceTests
+//    {
+//        [Fact]
+//        public async Task GetRouteTemplatesAsync_WithValidRequest_ReturnsRouteTemplateResponse()
+//        {
+//            // Arrange
+//            var httpClient = new HttpClient();
+//            var service = new RouteTemplateService(httpClient);
+//            var request = new RouteTemplateRequest
+//            {
+//                Authorization = new AuthorizationContext
+//                {
+//                    Url = "https://example.com",
+//                    ClientId = "123456",
+//                    ApiToken = "abc123"
+//                },
+//                SigningObjectType = SigningObjectType.DOCUMENT
+//            };
+//            var cancellationToken = CancellationToken.None;
+
+//            // Act
+//            var response = await service.GetRouteTemplatesAsync(request, cancellationToken);
+
+//            // Assert
+//            Assert.NotNull(response);
+//            Assert.True(response.Result);
+//            Assert.NotNull(response.SigningRouteTemplates);
+//        }
+
+//        [Fact]
+//        public async Task GetRouteTemplatesAsync_WithInvalidRequest_ThrowsHttpRequestException()
+//        {
+//            // Arrange
+//            var httpClient = new HttpClient();
+//            var service = new RouteTemplateService(httpClient);
+//            var request = new RouteTemplateRequest
+//            {
+//                Authorization = new AuthorizationContext
+//                {
+//                    Url = "https://example.com",
+//                    ClientId = "123456",
+//                    ApiToken = "abc123"
+//                },
+//                SigningObjectType = null // Invalid request
+//            };
+//            var cancellationToken = CancellationToken.None;
+
+//            // Act & Assert
+//            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request, cancellationToken));
+//        }
+
+//        [Fact]
+//        public async Task GetRouteTemplatesAsync_WithErrorResponse_ThrowsHttpRequestException()
+//        {
+//            // Arrange
+//            var httpClient = new HttpClient(new MockHttpMessageHandler(HttpStatusCode.BadRequest));
+//            var service = new RouteTemplateService(httpClient);
+//            var request = new RouteTemplateRequest
+//            {
+//                Authorization = new AuthorizationContext
+//                {
+//                    Url = "https://example.com",
+//                    ClientId = "123456",
+//                    ApiToken = "abc123"
+//                },
+//                SigningObjectType = SigningObjectType.DOCUMENT
+//            };
+//            var cancellationToken = CancellationToken.None;
+
+//            // Act & Assert
+//            await Assert.ThrowsAsync<HttpRequestException>(async () => await service.GetRouteTemplatesAsync(request, cancellationToken));
+//        }
+//    }
+
+//    // MockHttpMessageHandler to simulate HTTP response with a specific status code
+//    public class MockHttpMessageHandler : HttpMessageHandler
+//    {
+//        private readonly HttpStatusCode _statusCode;
+
+//        public MockHttpMessageHandler(HttpStatusCode statusCode)
+//        {
+//            _statusCode = statusCode;
+//        }
+
+//        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+//        {
+//            var response = new HttpResponseMessage(_statusCode);
+//            return Task.FromResult(response);
+//        }
+//    }
+//}


### PR DESCRIPTION
- Added a new HTTP POST endpoint for route templates in HRlink.API.http with Content-Type: application/json.
- Introduced RouteTemplateRequestIntegrationEventHandler class to handle integration events.
- Changed TemplateKey property in SigningRouteTemplate from enum to string.
- Added JSON converter for AutoSelectRuleType in SigningRouteTemplateParticipant.
- Registered RouteTemplateRequestIntegrationEventHandler service in Program.cs.
- Mapped POST requests for route templates to the new event handler in Program.cs.
- Added line to read response content as string in RouteTemplateService.cs.
- Added unit tests for RouteTemplateRequestIntegrationEventHandler.
- Updated RouteTemplateServiceTests to include tests for null requests and HTTP error responses.

### Refactor RouteTemplateService and Update Tests:
- Updated IRouteTemplateService to return nullable RouteTemplateResponse.
- Simplified error handling in RouteTemplateService.
- Refactored RouteTemplateServiceTests:
- Removed old test cases.
- Added new test cases for null request, valid request, and error responses.
- Added helper method for creating HttpClient with mock handler.

### Add Route Template Models, Service, and Registration:
- Introduced new namespace ParusRx.HRlink.API.Models with enums and records for route templates and signing routes.
- Added IRouteTemplateService interface and its implementation RouteTemplateService.
- Registered RouteTemplateService with HTTP client in Program.cs.
- Added commented-out unit tests for RouteTemplateService.